### PR TITLE
feat(listing): add listing page for medical departments

### DIFF
--- a/src/app/list/list.html
+++ b/src/app/list/list.html
@@ -1,1 +1,25 @@
-<h3>List Component Works!</h3>
+<header class="topbar">
+  <nav class="topbar-nav-container">
+    <button matButton class="back-btn" type="button">
+      <i [appFeatherIcon]="'arrow-left'" [width]="12" [height]="12"></i> Back to Dashboard
+    </button>
+    <h1 class="app-heading">Items List</h1>
+    <button matButton class="logout-btn" type="button">
+      <i [appFeatherIcon]="'log-out'" [width]="12" [height]="12"></i> Logout
+    </button>
+  </nav>
+</header>
+
+<main class="main-page">
+  <section class="list-section">
+    <h3 class="list-heading">Available Medical Departments</h3>
+    <mat-list class="list-container">
+      @for (dept of departments(); track dept.id) {
+        <mat-list-item class="list-item-container">
+          <div mat-line class="dept-name">{{ dept.name }}</div>
+          <div mat-line class="dept-desc">{{ dept.description }}</div>
+        </mat-list-item>
+      }
+    </mat-list>
+  </section>
+</main>

--- a/src/app/list/list.scss
+++ b/src/app/list/list.scss
@@ -1,0 +1,74 @@
+.topbar {
+  background-color: #ffffff;
+  padding: 1rem 8rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.topbar-nav-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-heading {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+  color: #171e25;
+}
+
+.logout-btn,
+.back-btn {
+  color: #171e25 !important;
+}
+
+.logout-btn:hover {
+  background: red;
+  color: #ffffff !important;
+}
+
+.back-btn:hover {
+  background: #394657;
+  color: #ffffff !important;
+}
+
+.main-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.list-section {
+  width: 89%;
+}
+
+.list-heading {
+  margin: 2rem 0;
+  font-size: 1.25rem;
+}
+
+.list-container {
+  padding: 0 !important;
+}
+
+.list-container > *:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.list-item-container {
+  background-color: #ffffff;
+  padding: 3rem 2rem;
+  border: 1px solid #e4e9f0;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.dept-name {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.dept-desc {
+  font-size: 0.875rem;
+}

--- a/src/app/list/list.ts
+++ b/src/app/list/list.ts
@@ -1,12 +1,36 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Signal, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { FeatherIconDirective } from '../shared/directives/feather-icon.directive';
+import { Department } from '../shared/models/department.model';
 
 @Component({
   standalone: true,
+  imports: [MatButtonModule, FeatherIconDirective, MatListModule],
   selector: 'app-list',
   templateUrl: './list.html',
   styleUrl: './list.scss',
 })
 export class ListComponent implements OnInit {
+  departments: Signal<Department[]> = signal<Department[]>([
+    {
+      id: 1,
+      name: 'Cardiology',
+      description:
+        'Specializes in diagnosing and treating diseases of the heart and blood vessels.',
+    },
+    {
+      id: 2,
+      name: 'Pediatrics',
+      description: 'Provides healthcare for infants, children, and adolescents.',
+    },
+    {
+      id: 3,
+      name: 'Orthopedics',
+      description: 'Focuses on conditions involving the musculoskeletal system.',
+    },
+  ]);
+
   constructor() {}
 
   ngOnInit() {}

--- a/src/app/shared/models/department.model.ts
+++ b/src/app/shared/models/department.model.ts
@@ -1,0 +1,5 @@
+export interface Department {
+  id: number;
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
- Added a topbar with:
  - Back to Dashboard button (with Feather icon)
  - Page heading
  - Logout button
- Implemented a Material Design list (`mat-list`) to display available medical departments.
- Integrated Angular Signals (`Signal<Item[]>`) to manage department data reactively.
- Used `@for` syntax with track-by for efficient rendering.
- Added semantic structure (header, main, section) for accessibility.