### PR TITLE
feat(auth): implement authentication with login, guard, interceptor, and mock API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@angular/material": "^20.2.3",
         "@angular/platform-browser": "^20.3.0",
         "@angular/router": "^20.3.0",
+        "angular-in-memory-web-api": "^0.20.0",
         "feather-icons": "^4.29.2",
+        "ngx-cookie-service": "^20.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3963,6 +3965,20 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/angular-in-memory-web-api": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/angular-in-memory-web-api/-/angular-in-memory-web-api-0.20.0.tgz",
+      "integrity": "sha512-piEcu1MvHOnPnESSFgzHEz9YUDxqQ1WbH8yp9f0sXr+//dTEEj/pY6YY7OthBSUP/DLTAEE4itE1SOYs0dOKMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0",
+        "@angular/core": "^20.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7552,6 +7568,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ngx-cookie-service": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-20.1.0.tgz",
+      "integrity": "sha512-g7Ddq8097qujmJfoEK27H12KLEpuO4SBPhoOYQ2kmLMSvz65vRrSKVwzOxdc75cFLQPW45Jfyyg3LoMTjKW0uA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0",
+        "@angular/core": "^20.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "@angular/material": "^20.2.3",
     "@angular/platform-browser": "^20.3.0",
     "@angular/router": "^20.3.0",
+    "angular-in-memory-web-api": "^0.20.0",
     "feather-icons": "^4.29.2",
+    "ngx-cookie-service": "^20.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,12 +1,34 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  importProvidersFrom,
+  provideBrowserGlobalErrorListeners,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
-
+import {
+  HTTP_INTERCEPTORS,
+  provideHttpClient,
+  withInterceptors,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryDataService } from './core/services/in-memory-data.service';
+import { AuthInterceptor } from './core/interceptors/auth.interceptor';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideHttpClient(withInterceptorsFromDi()),
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    importProvidersFrom(
+      HttpClientInMemoryWebApiModule.forRoot(InMemoryDataService, {
+        apiBase: '/api/',
+        delay: 400,
+        passThruUnknownUrl: true,
+      }),
+    ),
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes)
-  ]
+    provideRouter(routes),
+  ],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,11 +3,12 @@ import { LogInComponent } from './auth/login/login';
 import { DashboardComponent } from './dashboard/dashboard';
 import { ListComponent } from './list/list';
 import { NotFoundComponent } from './not-found/not-found';
+import { AuthGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
   { path: 'login', component: LogInComponent },
-  { path: 'dashboard', component: DashboardComponent },
-  { path: 'list', component: ListComponent },
+  { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard] },
+  { path: 'list', component: ListComponent, canActivate: [AuthGuard] },
   { path: '', redirectTo: '/login', pathMatch: 'full' },
   { path: '**', component: NotFoundComponent },
 ];

--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -1,0 +1,17 @@
+import { inject, Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  private auth = inject(AuthService);
+  private router = inject(Router);
+
+  canActivate(): boolean {
+    if (this.auth.isAuthenticated()) {
+      return true;
+    }
+    this.router.navigate(['/login']);
+    return false;
+  }
+}

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,36 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { CookieService } from 'ngx-cookie-service';
+import { tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+  private cookie = inject(CookieService);
+
+  login(email: string, password: string) {
+    return this.http
+      .post<{ token: string; user: { email: string } }>('/api/login', { email, password })
+      .pipe(
+        tap((res) => {
+          this.cookie.set('auth_token', res.token, { path: '/', secure: true });
+          this.cookie.set('user_email', res.user.email, { path: '/' });
+        }),
+      );
+  }
+
+  logout() {
+    this.cookie.delete('auth_token', '/');
+    this.cookie.delete('user_email', '/');
+  }
+
+  isAuthenticated() {
+    return this.cookie.check('auth_token');
+  }
+  getToken() {
+    return this.cookie.get('auth_token');
+  }
+  getUserEmail() {
+    return this.cookie.get('user_email');
+  }
+}

--- a/src/app/auth/login/login.html
+++ b/src/app/auth/login/login.html
@@ -49,6 +49,8 @@
       </mat-form-field>
     </div>
 
-    <button matButton="filled" type="submit" class="login-btn">Log in</button>
+    <button matButton="filled" type="submit" class="login-btn" [disabled]="isSubmitting()">
+      Log in
+    </button>
   </form>
 </div>

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,15 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from '../../auth/auth.service';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  private auth = inject(AuthService);
+
+  intercept<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
+    const token = this.auth.getToken();
+    const cloned = token ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }) : req;
+    return next.handle(cloned);
+  }
+}

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -1,0 +1,19 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Department } from '../../shared/models/department.model';
+import { Login } from '../../shared/models/login.model';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private http = inject(HttpClient);
+  private baseUrl = '/api';
+
+  login(email: string, password: string): Observable<Login> {
+    return this.http.post<Login>(`${this.baseUrl}/login`, { email, password });
+  }
+
+  getDepartments(): Observable<Department[]> {
+    return this.http.get<Department[]>(`${this.baseUrl}/departments`);
+  }
+}

--- a/src/app/core/services/in-memory-data.service.ts
+++ b/src/app/core/services/in-memory-data.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { InMemoryDbService, RequestInfo, ResponseOptions, STATUS } from 'angular-in-memory-web-api';
+import { Observable } from 'rxjs';
+import { Department } from '../../shared/models/department.model';
+
+@Injectable({ providedIn: 'root' })
+export class InMemoryDataService implements InMemoryDbService {
+  createDb() {
+    const departments: Department[] = [
+      {
+        id: 1,
+        name: 'Cardiology',
+        description:
+          'Specializes in diagnosing and treating diseases of the heart and blood vessels.',
+      },
+      {
+        id: 2,
+        name: 'Pediatrics',
+        description: 'Provides healthcare for infants, children, and adolescents.',
+      },
+      {
+        id: 3,
+        name: 'Orthopedics',
+        description: 'Focuses on conditions involving the musculoskeletal system.',
+      },
+    ];
+    return { departments };
+  }
+
+  post(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
+    if (reqInfo.url.endsWith('/api/login')) {
+      return this.handleLogin(reqInfo);
+    }
+    return undefined;
+  }
+
+  get(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
+    if (reqInfo.collectionName === 'departments') {
+      return this.handleItems(reqInfo);
+    }
+    return undefined;
+  }
+
+  private handleLogin(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
+    const { email, password } = reqInfo.utils.getJsonBody(reqInfo.req) ?? {};
+
+    if (password && String(password).trim() !== '') {
+      const body = {
+        token: 'fake-jwt-token-12345',
+        user: { email },
+      };
+      const options: ResponseOptions = { status: STATUS.OK, body };
+      return reqInfo.utils.createResponse$(() => options);
+    }
+
+    const options: ResponseOptions = {
+      status: STATUS.UNAUTHORIZED,
+      body: { error: 'Invalid credentials' },
+    };
+    return reqInfo.utils.createResponse$(() => options);
+  }
+
+  private handleItems(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
+    const req = reqInfo.req as Request;
+    const authHeader = req.headers.get('Authorization');
+
+    if (authHeader === 'Bearer fake-jwt-token-12345') {
+      return undefined;
+    } else {
+      const options: ResponseOptions = {
+        status: STATUS.UNAUTHORIZED,
+        body: { error: 'Missing or invalid token' },
+      };
+      return reqInfo.utils.createResponse$(() => options);
+    }
+  }
+}

--- a/src/app/dashboard/dashboard.ts
+++ b/src/app/dashboard/dashboard.ts
@@ -9,8 +9,4 @@ import { FeatherIconDirective } from '../shared/directives/feather-icon.directiv
   templateUrl: './dashboard.html',
   styleUrl: './dashboard.scss',
 })
-export class DashboardComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class DashboardComponent {}

--- a/src/app/list/list.ts
+++ b/src/app/list/list.ts
@@ -31,7 +31,5 @@ export class ListComponent implements OnInit {
     },
   ]);
 
-  constructor() {}
-
   ngOnInit() {}
 }

--- a/src/app/not-found/not-found.ts
+++ b/src/app/not-found/not-found.ts
@@ -6,8 +6,4 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './not-found.html',
   styleUrl: './not-found.scss',
 })
-export class NotFoundComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class NotFoundComponent {}

--- a/src/app/shared/directives/feather-icon.directive.ts
+++ b/src/app/shared/directives/feather-icon.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, OnChanges } from '@angular/core';
+import { Directive, ElementRef, inject, Input, OnChanges } from '@angular/core';
 import feather from 'feather-icons';
 
 type FeatherIconName = keyof typeof feather.icons;
@@ -12,7 +12,7 @@ export class FeatherIconDirective implements OnChanges {
   @Input() width?: number;
   @Input() height?: number;
 
-  constructor(private el: ElementRef<HTMLElement>) {}
+  private el = inject(ElementRef<HTMLElement>);
 
   ngOnChanges(): void {
     const icon = feather.icons[this.iconName];

--- a/src/app/shared/models/login.model.ts
+++ b/src/app/shared/models/login.model.ts
@@ -1,0 +1,4 @@
+export interface Login {
+  token: string;
+  user: { email: string };
+}


### PR DESCRIPTION
Added a complete authentication flow using cookies + JWT, protects routes, and integrates a mock backend via `angular-in-memory-web-api`.

## Features
- **Login Page**
  - Calls `POST /api/login`; stores token and user email in cookies
  - Redirects to **/dashboard** on success
- **Auth Guard**
  - Protects `/dashboard` and `/list`
  - Redirects unauthenticated users to `/login`
- **Auth Interceptor**
  - Attaches `Authorization: Bearer <token>` to API requests
- **Mock API (In-Memory)**
  - `POST /api/login` → returns `{ token, user }` if password is non-empty
  - `GET /api/departments` → requires valid `Authorization` header
- **Services**
  - `AuthService` for login/logout, cookie handling
  - `ApiService` for API calls (login, get_departments)

