### PR TITLE
feat: fetch and display department list from API with reusable state components and lazy loading

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,14 +1,17 @@
 import { Routes } from '@angular/router';
 import { LogInComponent } from './auth/login/login';
 import { DashboardComponent } from './dashboard/dashboard';
-import { ListComponent } from './list/list';
 import { NotFoundComponent } from './not-found/not-found';
 import { AuthGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
   { path: 'login', component: LogInComponent },
   { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard] },
-  { path: 'list', component: ListComponent, canActivate: [AuthGuard] },
+  {
+    path: 'list',
+    canActivate: [AuthGuard],
+    loadComponent: () => import('./list/list').then((m) => m.ListComponent),
+  },
   { path: '', redirectTo: '/login', pathMatch: 'full' },
   { path: '**', component: NotFoundComponent },
 ];

--- a/src/app/auth/login/login.ts
+++ b/src/app/auth/login/login.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { finalize } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
@@ -29,6 +29,7 @@ export class LogInComponent implements OnInit {
   private fb = inject(FormBuilder);
   private auth = inject(AuthService);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
     this.loginForm = this.fb.group({
@@ -50,7 +51,7 @@ export class LogInComponent implements OnInit {
       .login(email, password)
       .pipe(
         finalize(() => this.isSubmitting.set(false)),
-        takeUntilDestroyed(),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: () => {

--- a/src/app/core/services/in-memory-data.service.ts
+++ b/src/app/core/services/in-memory-data.service.ts
@@ -35,13 +35,13 @@ export class InMemoryDataService implements InMemoryDbService {
   }
 
   get(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
-    if (reqInfo.collectionName === 'departments') {
+    if (reqInfo.url.endsWith('/api/departments')) {
       return this.handleItems(reqInfo);
     }
     return undefined;
   }
 
-  private handleLogin(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
+  private handleLogin(reqInfo: RequestInfo): Observable<ResponseOptions> {
     const { email, password } = reqInfo.utils.getJsonBody(reqInfo.req) ?? {};
 
     if (password && String(password).trim() !== '') {
@@ -60,18 +60,25 @@ export class InMemoryDataService implements InMemoryDbService {
     return reqInfo.utils.createResponse$(() => options);
   }
 
-  private handleItems(reqInfo: RequestInfo): Observable<ResponseOptions> | undefined {
+  private handleItems(reqInfo: RequestInfo): Observable<ResponseOptions> {
     const req = reqInfo.req as Request;
     const authHeader = req.headers.get('Authorization');
 
-    if (authHeader === 'Bearer fake-jwt-token-12345') {
-      return undefined;
-    } else {
-      const options: ResponseOptions = {
+    if (authHeader !== 'Bearer fake-jwt-token-12345') {
+      const unauthorized: ResponseOptions = {
         status: STATUS.UNAUTHORIZED,
         body: { error: 'Missing or invalid token' },
       };
-      return reqInfo.utils.createResponse$(() => options);
+      return reqInfo.utils.createResponse$(() => unauthorized);
     }
+
+    const db = reqInfo.utils.getDb() as { departments: Department[] };
+    const departments = db?.departments ?? [];
+
+    const options: ResponseOptions = {
+      status: STATUS.OK,
+      body: departments,
+    };
+    return reqInfo.utils.createResponse$(() => options);
   }
 }

--- a/src/app/list/list.html
+++ b/src/app/list/list.html
@@ -11,15 +11,23 @@
 </header>
 
 <main class="main-page">
-  <section class="list-section">
-    <h3 class="list-heading">Available Medical Departments</h3>
-    <mat-list class="list-container">
-      @for (dept of departments(); track dept.id) {
-        <mat-list-item class="list-item-container">
-          <div mat-line class="dept-name">{{ dept.name }}</div>
-          <div mat-line class="dept-desc">{{ dept.description }}</div>
-        </mat-list-item>
-      }
-    </mat-list>
-  </section>
+  @if (isLoading()) {
+    <app-loading-spinner></app-loading-spinner>
+  } @else if (!isLoading() && !error() && departments().length === 0) {
+    <app-empty-state></app-empty-state>
+  } @else if (!isLoading() && !error() && departments().length) {
+    <section class="list-section">
+      <h3 class="list-heading">Available Medical Departments</h3>
+      <mat-list class="list-container">
+        @for (dept of departments(); track dept.id) {
+          <mat-list-item class="list-item-container">
+            <div mat-line class="dept-name">{{ dept.name }}</div>
+            <div mat-line class="dept-desc">{{ dept.description }}</div>
+          </mat-list-item>
+        }
+      </mat-list>
+    </section>
+  } @else if (!isLoading() && error()) {
+    <app-error-block></app-error-block>
+  }
 </main>

--- a/src/app/list/list.scss
+++ b/src/app/list/list.scss
@@ -72,3 +72,9 @@
 .dept-desc {
   font-size: 0.875rem;
 }
+
+app-loading-spinner,
+app-error-block,
+app-empty-state {
+  margin-top: 12%;
+}

--- a/src/app/list/list.ts
+++ b/src/app/list/list.ts
@@ -1,42 +1,58 @@
-import { Component, inject, OnInit, Signal, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, Signal, signal } from '@angular/core';
 import { Router } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
 import { FeatherIconDirective } from '../shared/directives/feather-icon.directive';
 import { Department } from '../shared/models/department.model';
 import { HelperService } from '../core/services/helper.service';
+import { ApiService } from '../core/services/api.service';
+import { finalize } from 'rxjs';
+import { LoadingSpinnerComponent } from '../shared/components/loading-spinner/loading-spinner';
+import { ErrorBlockComponent } from '../shared/components/error-block/error-block';
+import { EmptyStateComponent } from '../shared/components/empty-state/empty-state';
 
 @Component({
   standalone: true,
-  imports: [MatButtonModule, FeatherIconDirective, MatListModule],
+  imports: [
+    MatButtonModule,
+    FeatherIconDirective,
+    MatListModule,
+    LoadingSpinnerComponent,
+    ErrorBlockComponent,
+    EmptyStateComponent,
+  ],
   selector: 'app-list',
   templateUrl: './list.html',
   styleUrl: './list.scss',
 })
 export class ListComponent implements OnInit {
-  departments: Signal<Department[]> = signal<Department[]>([
-    {
-      id: 1,
-      name: 'Cardiology',
-      description:
-        'Specializes in diagnosing and treating diseases of the heart and blood vessels.',
-    },
-    {
-      id: 2,
-      name: 'Pediatrics',
-      description: 'Provides healthcare for infants, children, and adolescents.',
-    },
-    {
-      id: 3,
-      name: 'Orthopedics',
-      description: 'Focuses on conditions involving the musculoskeletal system.',
-    },
-  ]);
+  departments = signal<Department[]>([]);
+  isLoading = signal<boolean>(false);
+  error = signal<string | null>(null);
 
   private helperService = inject(HelperService);
   private router = inject(Router);
+  private api = inject(ApiService);
+  private destroyRef = inject(DestroyRef);
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.fetchDepartments();
+  }
+
+  fetchDepartments(): void {
+    (this.isLoading.set(true),
+      this.api
+        .getDepartments()
+        .pipe(
+          finalize(() => this.isLoading.set(false)),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe({
+          next: (data) => this.departments.set(data),
+          error: (err) => this.error.set('Failed to load departments. Please try again.'),
+        }));
+  }
 
   onLogout(): void {
     this.helperService.logout();

--- a/src/app/shared/components/empty-state/empty-state.html
+++ b/src/app/shared/components/empty-state/empty-state.html
@@ -1,0 +1,6 @@
+<div class="empty-container">
+  <p class="title">
+    <i [appFeatherIcon]="'alert-triangle'" [width]="12" [height]="12"></i> {{ title }}
+  </p>
+  <p class="subtitle">{{ subtitle }}</p>
+</div>

--- a/src/app/shared/components/empty-state/empty-state.scss
+++ b/src/app/shared/components/empty-state/empty-state.scss
@@ -1,0 +1,11 @@
+.empty-container {
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.title {
+  color: #394657;
+}
+.subtitle {
+  color: #5a6a7c;
+}

--- a/src/app/shared/components/empty-state/empty-state.ts
+++ b/src/app/shared/components/empty-state/empty-state.ts
@@ -1,0 +1,16 @@
+// shared/components/empty-state/empty-state.component.ts
+import { Component, Input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { FeatherIconDirective } from '../../directives/feather-icon.directive';
+
+@Component({
+  standalone: true,
+  selector: 'app-empty-state',
+  imports: [MatIconModule, FeatherIconDirective],
+  templateUrl: './empty-state.html',
+  styleUrl: './empty-state.scss',
+})
+export class EmptyStateComponent {
+  @Input() title = 'No data available';
+  @Input() subtitle = 'Please add some items to get started.';
+}

--- a/src/app/shared/components/error-block/error-block.html
+++ b/src/app/shared/components/error-block/error-block.html
@@ -1,0 +1,6 @@
+<mat-card class="error-block">
+  <mat-card-title>Error</mat-card-title>
+  <mat-card-content>
+    <p>{{ message }}</p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/shared/components/error-block/error-block.scss
+++ b/src/app/shared/components/error-block/error-block.scss
@@ -1,0 +1,14 @@
+.error-block {
+  padding: 20px;
+  background-color: #fff5f5;
+  border-left: 4px solid #f44336;
+}
+mat-card-title {
+  font-weight: 600;
+}
+mat-card-content {
+  padding: 0 !important;
+}
+p {
+  color: #d32f2f;
+}

--- a/src/app/shared/components/error-block/error-block.ts
+++ b/src/app/shared/components/error-block/error-block.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  standalone: true,
+  selector: 'app-error-block',
+  imports: [MatCardModule, MatButtonModule],
+  templateUrl: './error-block.html',
+  styleUrl: './error-block.scss',
+})
+export class ErrorBlockComponent {
+  @Input() message = 'Something went wrong. Please try again.';
+}

--- a/src/app/shared/components/loading-spinner/loading-spinner.html
+++ b/src/app/shared/components/loading-spinner/loading-spinner.html
@@ -1,0 +1,12 @@
+<div class="loading-container">
+  <mat-progress-spinner
+    mode="indeterminate"
+    [diameter]="diameter"
+    [strokeWidth]="strokeWidth"
+    color="primary"
+  >
+  </mat-progress-spinner>
+  @if (message) {
+    <p>{{ message }}</p>
+  }
+</div>

--- a/src/app/shared/components/loading-spinner/loading-spinner.scss
+++ b/src/app/shared/components/loading-spinner/loading-spinner.scss
@@ -1,0 +1,12 @@
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+p {
+  margin-top: 8px;
+  font-size: 0.9rem;
+  color: #555;
+}

--- a/src/app/shared/components/loading-spinner/loading-spinner.ts
+++ b/src/app/shared/components/loading-spinner/loading-spinner.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  standalone: true,
+  selector: 'app-loading-spinner',
+  imports: [MatProgressSpinnerModule],
+  templateUrl: './loading-spinner.html',
+  styleUrl: './loading-spinner.scss',
+})
+export class LoadingSpinnerComponent {
+  @Input() message = 'Loading...';
+  @Input() diameter = 40;
+  @Input() strokeWidth = 4;
+}


### PR DESCRIPTION
- Implemented **API integration** using `ApiService` to fetch departments from `/api/departments`.
- Updated `ListComponent` to fetch and render department data dynamically.
- Introduced reusable state components:
  - **loading-spinner** → shows while data is being fetched.
  - **error-block** → shows when API returns an error.
  - **empty-state** → shows when API returns an empty list.
- Updated `app.routes.ts` to **lazy load ListComponent** with `loadComponent` and `AuthGuard`.

